### PR TITLE
Added capability to save output in grib2 format

### DIFF
--- a/NCEP/Readme.md
+++ b/NCEP/Readme.md
@@ -43,6 +43,16 @@ conda install --channel conda-forge cartopy
 pip install --upgrade https://github.com/deepmind/graphcast/archive/master.zip
 ```
 
+If you would like to save as grib2 format, two more packages are needed:
+
+```bash
+conda install conda-forge::iris
+````
+
+```bash
+conda install conda-forge::iris-grib
+````
+
 This will install the packages and most of their dependencies.
 
 

--- a/NCEP/Readme.md
+++ b/NCEP/Readme.md
@@ -43,14 +43,17 @@ conda install --channel conda-forge cartopy
 pip install --upgrade https://github.com/deepmind/graphcast/archive/master.zip
 ```
 
-If you would like to save as grib2 format, two more packages are needed:
+If you would like to save as grib2 format, the following packages are needed:
 
 ```bash
-conda install conda-forge::iris
+pip install ecmwflibs
+````
+```bash
+pip install iris
 ````
 
 ```bash
-conda install conda-forge::iris-grib
+pip install iris-grib
 ````
 
 This will install the packages and most of their dependencies.

--- a/NCEP/cronjob_cloud.sh
+++ b/NCEP/cronjob_cloud.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-sbatch /lustre/Sadegh.Tabas/graphcast/NCEP/gc_job_cloud.sh
+sbatch /contrib/Sadegh.Tabas/operational/graphcast/NCEP/gc_job_cloud.sh

--- a/NCEP/gc_job_cloud.sh
+++ b/NCEP/gc_job_cloud.sh
@@ -47,7 +47,7 @@ source /contrib/Sadegh.Tabas/miniconda3/etc/profile.d/conda.sh
 conda activate mlwp
 
 # going to the model directory
-cd /lustre/Sadegh.Tabas/graphcast/NCEP/
+cd /contrib/Sadegh.Tabas/operational/graphcast/NCEP/
 
 start_time=$(date +%s)
 echo "start runing gdas utility to generate graphcast inputs for: $curr_datetime"

--- a/NCEP/run_graphcast.py
+++ b/NCEP/run_graphcast.py
@@ -47,7 +47,7 @@ class GraphCastModel:
         self.targets = None
         self.forcings = None
         self.s3_bucket_name = "noaa-nws-graphcastgfs-pds"
-        self.start_datetime = None
+        self.dates = None
 
     def load_pretrained_model(self, pretrained_model_path):
         """Load pre-trained GraphCast model."""
@@ -63,7 +63,7 @@ class GraphCastModel:
         #with open(gdas_data_path, "rb") as f:
         #    self.current_batch = xarray.load_dataset(f).compute()
         self.current_batch = xarray.load_dataset(gdas_data_path).compute()
-        self.start_datetime =  pd.to_datetime(self.current_batch.datetime[0][0].values)
+        self.dates =  pd.to_datetime(self.current_batch.datetime.values)
         
         if (forecast_length + 2) > len(self.current_batch['time']):
             print('Updating batch dataset to account for forecast length')
@@ -182,7 +182,7 @@ class GraphCastModel:
         forecasts.to_netcdf(f"{new_fname}")
 
         #extract time slab and save as grib2 format
-        utils.save_grib2(self.start_datetime, new_fname, outdir)
+        utils.save_grib2(self.dates, new_fname, outdir)
 
         #remove intermediate nc file
         if os.path.isfile(new_fname):

--- a/NCEP/upload_to_s3bucket.py
+++ b/NCEP/upload_to_s3bucket.py
@@ -1,4 +1,5 @@
 import argparse
+import glob
 from run_graphcast import GraphCastModel
 
 def upload_to_s3_wrapper(input_path, output_path, keep):
@@ -13,4 +14,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
     keep = False
 
-    upload_to_s3_wrapper(args.input, args.output, keep)
+    output_files = glob.glob('graphcastgfs*')
+    output_files.sort()
+    output_files.append(args.output)
+
+    upload_to_s3_wrapper(args.input, output_files, keep)

--- a/NCEP/upload_to_s3bucket.py
+++ b/NCEP/upload_to_s3bucket.py
@@ -1,5 +1,4 @@
 import argparse
-import glob
 from run_graphcast import GraphCastModel
 
 def upload_to_s3_wrapper(input_path, output_path, keep):
@@ -14,8 +13,4 @@ if __name__ == "__main__":
     args = parser.parse_args()
     keep = False
 
-    output_files = glob.glob('graphcastgfs*')
-    output_files.sort()
-    output_files.append(args.output)
-
-    upload_to_s3_wrapper(args.input, output_files, keep)
+    upload_to_s3_wrapper(args.input, args.output, keep)

--- a/NCEP/utils.py
+++ b/NCEP/utils.py
@@ -76,8 +76,6 @@ def save_grib2(start_datetime, filename, outdir):
      
         print(outfile)
     
-        new_list = []
-    
         for cube in cubes:
             var_name = cube.name()
         

--- a/NCEP/utils.py
+++ b/NCEP/utils.py
@@ -77,7 +77,7 @@ def save_grib2(dates, filename, outdir):
     for date in datevectors:
         print(f"Processing for time {date.strftime('%Y-%m-%d %H:00:00')}")
         hrs = int((date - forecast_starttime).total_seconds() // 3600)
-        outfile = str(outdir / f'graphcastgfs.t{cycle:02d}z.f{hrs:03d}')
+        outfile = str(outdir / f'gcgfs.t{cycle:02d}z.f{hrs:03d}')
      
         print(outfile)
     

--- a/NCEP/utils.py
+++ b/NCEP/utils.py
@@ -34,7 +34,7 @@ def tweaked_messages(cube, time_range):
             eccodes.codes_set(grib_message, 'stepRange', time_range)
             eccodes.codes_set(grib_message, 'discipline', 0)
             eccodes.codes_set(grib_message, 'parameterCategory', 1)
-            eccodes.codes_set(grib_message, 'parameterNumber', 52)
+            eccodes.codes_set(grib_message, 'parameterNumber', 8)
             eccodes.codes_set(grib_message, 'typeOfFirstFixedSurface', 1)
             eccodes.codes_set(grib_message, 'typeOfStatisticalProcessing', 1)
 
@@ -97,14 +97,12 @@ def save_grib2(start_datetime, filename, outdir):
                     cube_slice_level.add_aux_coord(iris.coords.DimCoord(hrs, standard_name='forecast_period', units='hours'))
                     cube_slice_level.standard_name = ATTR_MAPS[var_name][1]
                     cube_slice_level.units = ATTR_MAPS[var_name][2]
-                    cube_slice_level.short_name = ATTR_MAPS[var_name][3]
                     iris.save(cube_slice_level, outfile, saver='grib2', append=True)
             else:
                 cube_slice.add_aux_coord(iris.coords.DimCoord(hrs, standard_name='forecast_period', units='hours'))
                 cube_slice.standard_name = ATTR_MAPS[var_name][1]
                 cube_slice.units = ATTR_MAPS[var_name][2]
                 #cube_slice.long_name = var_name
-                cube_slice.short_name = ATTR_MAPS[var_name][3]
     
                 if var_name not in ['mean_sea_level_pressure', 'total_precipitation_6hr']:
                     cube_slice.add_aux_coord(iris.coords.DimCoord(ATTR_MAPS[var_name][0], standard_name='height', units='m'))

--- a/NCEP/utils.py
+++ b/NCEP/utils.py
@@ -42,7 +42,7 @@ def tweaked_messages(cube, time_range):
             eccodes.codes_set(grib_message, 'discipline', 0)
             eccodes.codes_set(grib_message, 'parameterCategory', 3)
             eccodes.codes_set(grib_message, 'parameterNumber', 1)
-            eccodes.codes_set(grib_message, 'typeOfFirstFixedSurface', 102)
+            eccodes.codes_set(grib_message, 'typeOfFirstFixedSurface', 101)
 
     yield grib_message
 

--- a/NCEP/utils.py
+++ b/NCEP/utils.py
@@ -68,7 +68,7 @@ def save_grib2(start_datetime, filename, outdir):
     new_time_points = [new_time_unit.date2num(dt) for dt in datevectors]
     new_time_coord = iris.coords.DimCoord(new_time_points, standard_name='time', units=new_time_unit)
 
-    for date in datevectors[:2]:
+    for date in datevectors:
         print(f"Processing for time {date.strftime('%Y-%m-%d %H:00:00')}")
         hrs = int((date - start_datetime).total_seconds() // 3600)
         outfile = str(outdir / f'graphcastgfs.t{cycle:02d}z.f{hrs:03d}.grib2')

--- a/NCEP/utils.py
+++ b/NCEP/utils.py
@@ -60,10 +60,9 @@ def save_grib2(dates, filename, outdir):
     cubes = iris.load(filename)
     times = cubes[0].coord('time').points
 
-    model_starttime = dates[0][0]
-    cycle = model_starttime.hour
 
     forecast_starttime = dates[0][1]
+    cycle = forecast_starttime.hour
     print(f'Forecast start time is {forecast_starttime}')
     #get forecast datevectors
     datevectors = [forecast_starttime + timedelta(hours=int(t)) for t in times]
@@ -77,7 +76,7 @@ def save_grib2(dates, filename, outdir):
 
     for date in datevectors:
         print(f"Processing for time {date.strftime('%Y-%m-%d %H:00:00')}")
-        hrs = int((date - model_starttime).total_seconds() // 3600)
+        hrs = int((date - forecast_starttime).total_seconds() // 3600)
         outfile = str(outdir / f'graphcastgfs.t{cycle:02d}z.f{hrs:03d}')
      
         print(outfile)

--- a/NCEP/utils.py
+++ b/NCEP/utils.py
@@ -1,0 +1,103 @@
+"""A collection of utilily functions.
+
+    Functions:
+        save_grib2: This function reads data from a netcdf file and save them as grib2 format.
+
+    History:
+        01/26/2024: Linlin Cui (linlin.cui@noaa.gov), added function save_grib2 
+"""
+
+from datetime import datetime, timedelta
+import cf_units
+import iris
+
+ATTR_MAPS = {
+    '10m_u_component_of_wind': [10, 'x_wind', 'm s**-1'],
+    '10m_v_component_of_wind': [10, 'x_wind', 'm s**-1'],
+    'mean_sea_level_pressure': [0, 'air_pressure_at_sea_level', 'Pa'],
+    '2m_temperature': [2, 'air_temperature', 'K'],
+    'total_precipitation_6hr': [0, 'precipitation_amount', 'kg m**-2'],
+    'vertical_velocity': [None, 'lagrangian_tendency_of_air_pressure', 'Pa s**-1'],
+    'specific_humidity': [None, 'specific_humidity', 'kg kg**-1'],
+    'temperature': [None, 'air_temperature', 'K'],
+    'geopotential': [None, 'geopotential_height', 'm'],
+    'u_component_of_wind': [None, 'x_wind', 'm s**-1'],
+    'v_component_of_wind': [None, 'y_wind', 'm s**-1'],
+}
+
+
+def save_grib2(start_datetime, filename):
+    """Convert netcdf file to grib2 format file
+
+    Args:
+      start_datetime: datetime object, which specify model's start time
+      filename: file name, including the path
+
+    Returns:
+      No return values, will save to grib2 file
+    """
+
+    cubes = iris.load(filename)
+    times = cubes[0].coord('time').points
+    datevectors = [start_datetime + timedelta(hours=int(t)) for t in times]
+
+    time_fmt_str = '00:00:00'
+    time_unit_str = f"Hours since {start_datetime.strftime('%Y-%m-%d %H:00:00')}"
+    time_coord = cubes[0].coord('time')
+    new_time_unit = cf_units.Unit(time_unit_str, calendar=cf_units.CALENDAR_STANDARD)
+    new_time_points = [new_time_unit.date2num(dt) for dt in datevectors]
+    new_time_coord = iris.coords.DimCoord(new_time_points, standard_name='time', units=new_time_unit)
+
+    for date in datevectors:
+        print(f"Processing for time {date.strftime('%Y-%m-%d %H:00:00')}")
+        hrs = int((date - start_datetime).total_seconds() // 3600)
+        print(hrs)
+    
+        new_list = []
+    
+        for cube in cubes:
+            var_name = cube.name()
+        
+            time_coord_dim = cube.coord_dims('time')
+            cube.remove_coord('time')
+            cube.add_dim_coord(new_time_coord, time_coord_dim)
+            
+            hour_6 = iris.Constraint(time=iris.time.PartialDateTime(month=date.month, day=date.day, hour=date.hour))
+            cube_slice = cube.extract(hour_6)
+            cube_slice.coord('latitude').coord_system=iris.coord_systems.GeogCS(4326)
+            cube_slice.coord('longitude').coord_system=iris.coord_systems.GeogCS(4326)
+    
+            if len(cube_slice.data.shape) == 3:
+                levels = cube_slice.coord('pressure').points
+                for level in levels:
+                    cube_slice_level = cube_slice.extract(iris.Constraint(pressure=level))
+                    cube_slice_level.add_aux_coord(iris.coords.DimCoord(hrs, standard_name='forecast_period', units='hours'))
+                    cube_slice_level.standard_name = ATTR_MAPS[var_name][1]
+                    cube_slice_level.units = ATTR_MAPS[var_name][2]
+                    cube_slice_level.long_name = var_name
+                    new_list.append(cube_slice_level)
+            else:
+                cube_slice.add_aux_coord(iris.coords.DimCoord(hrs, standard_name='forecast_period', units='hours'))
+    
+                if var_name not in ['mean_sea_level_pressure', 'total_precipitation_6hr']:
+                    cube_slice.add_aux_coord(iris.coords.DimCoord(ATTR_MAPS[var_name][0], standard_name='height', units='m'))
+                #TODO: figure out how to set levelType to meanSea
+                #if var_name == 'mean_sea_level_pressure':
+                #    cube_slice.add_aux_coord(iris.coords.DimCoord(ATTR_MAPS[var_name][0], standard_name='height', units='m'))
+    
+                #This part is not working right now, may look into eccodes sourcecode
+                if var_name == 'total_precipitation_6hr':
+                    cube_slice.stepType = 'accum'
+                    cube_slice.stepRange = f'{hrs-6}-{hrs}'
+                    cube_slice.stepUnits = 1
+                    cube_slice.step = 6
+                    cube_slice.startStep = hrs - 6
+                    cube_slice.endStep = hrs
+    
+                cube_slice.standard_name = ATTR_MAPS[var_name][1]
+                cube_slice.units = ATTR_MAPS[var_name][2]
+                cube_slice.long_name = var_name
+                new_list.append(cube_slice)
+        
+        cycle = start_datetime.hour
+        iris.save(new_list, f'graphcast.t{cycle:02d}z.f{hrs:03d}.grib2')

--- a/NCEP/utils.py
+++ b/NCEP/utils.py
@@ -46,11 +46,11 @@ def tweaked_messages(cube, time_range):
 
     yield grib_message
 
-def save_grib2(start_datetime, filename, outdir):
+def save_grib2(dates, filename, outdir):
     """Convert netcdf file to grib2 format file
 
     Args:
-      start_datetime: datetime object, which specify model's start time
+      dates: array of datetime object, from source file
       filename: file name, including the path
 
     Returns:
@@ -59,11 +59,17 @@ def save_grib2(start_datetime, filename, outdir):
 
     cubes = iris.load(filename)
     times = cubes[0].coord('time').points
-    datevectors = [start_datetime + timedelta(hours=int(t)) for t in times]
-    cycle = start_datetime.hour
+
+    model_starttime = dates[0][0]
+    cycle = model_starttime.hour
+
+    forecast_starttime = dates[0][1]
+    print(f'Forecast start time is {forecast_starttime}')
+    #get forecast datevectors
+    datevectors = [forecast_starttime + timedelta(hours=int(t)) for t in times]
 
     time_fmt_str = '00:00:00'
-    time_unit_str = f"Hours since {start_datetime.strftime('%Y-%m-%d %H:00:00')}"
+    time_unit_str = f"Hours since {forecast_starttime.strftime('%Y-%m-%d %H:00:00')}"
     time_coord = cubes[0].coord('time')
     new_time_unit = cf_units.Unit(time_unit_str, calendar=cf_units.CALENDAR_STANDARD)
     new_time_points = [new_time_unit.date2num(dt) for dt in datevectors]
@@ -71,7 +77,7 @@ def save_grib2(start_datetime, filename, outdir):
 
     for date in datevectors:
         print(f"Processing for time {date.strftime('%Y-%m-%d %H:00:00')}")
-        hrs = int((date - start_datetime).total_seconds() // 3600)
+        hrs = int((date - model_starttime).total_seconds() // 3600)
         outfile = str(outdir / f'graphcastgfs.t{cycle:02d}z.f{hrs:03d}')
      
         print(outfile)


### PR DESCRIPTION
### Description
This PR updated the run_graphcast.py script to provide an option to save output in grib2 format if argument "output" endswith "grib2" and added a new script utils.py to save utility functions. If in grib2 format, files will be saved one file per time, e.g., f006, f012, and so on.

### Linked Issues
- Closes https://github.com/NOAA-EMC/graphcast/issues/23

### Blocking Dependencies
<!-- Example: "- Depends on #1733" or "None" -->

## Anticipated Changes
### Input data
- [x] No changes are expected to input data.
- [ ] Changes are expected to input data:
  - [ ] New input data.
  - [ ] Updated input data.

### Needed libraries
<!-- Library updates take time. If this PR needs updates to libraries, please make sure to accomplish the following tasks -->
- iris (https://github.com/SciTools/iris)
- iris-grib (https://github.com/SciTools/iris-grib)