### PR TITLE
Update pygrib method to account for 37 levels

### DIFF
--- a/NCEP/gcjob_13pl_cloud.sh
+++ b/NCEP/gcjob_13pl_cloud.sh
@@ -51,6 +51,15 @@ echo "number of pressure levels: $num_pressure_levels"
 source /contrib/Sadegh.Tabas/miniconda3/etc/profile.d/conda.sh
 conda activate mlwp
 
+# Specify the path to your custom AWS credentials file
+custom_credentials_file="/contrib/Sadegh.Tabas/.aws/credentials"
+# Specify the path to your custom AWS config file
+custom_config_file="/contrib/Sadegh.Tabas/.aws/config"
+
+# Set the environment variables
+export AWS_SHARED_CREDENTIALS_FILE="$custom_credentials_file"
+export AWS_CONFIG_FILE="$custom_config_file"
+
 # going to the model directory
 cd /contrib/Sadegh.Tabas/operational/graphcast/NCEP/
 

--- a/NCEP/gcjob_37pl_cloud.sh
+++ b/NCEP/gcjob_37pl_cloud.sh
@@ -51,6 +51,15 @@ echo "number of pressure levels: $num_pressure_levels"
 source /contrib/Sadegh.Tabas/miniconda3/etc/profile.d/conda.sh
 conda activate mlwp
 
+# Specify the path to your custom AWS credentials file
+custom_credentials_file="/contrib/Sadegh.Tabas/.aws/credentials"
+# Specify the path to your custom AWS config file
+custom_config_file="/contrib/Sadegh.Tabas/.aws/config"
+
+# Set the environment variables
+export AWS_SHARED_CREDENTIALS_FILE="$custom_credentials_file"
+export AWS_CONFIG_FILE="$custom_config_file"
+
 # going to the model directory
 cd /contrib/Sadegh.Tabas/operational/graphcast/NCEP/
 

--- a/NCEP/gdas_utility.py
+++ b/NCEP/gdas_utility.py
@@ -50,8 +50,8 @@ class GFSDataProcessor:
 
             self.s3 = boto3.client('s3')
     
-            # Specify the S3 bucket name and root directory
-            self.bucket_name = 'noaa-ncepdev-none-ca-ufs-cpldcld'
+        # Specify the S3 bucket name and root directory
+        self.bucket_name = 'noaa-ncepdev-none-ca-ufs-cpldcld'
         
         self.root_directory = 'gdas'
 


### PR DESCRIPTION
### Description
- This PR updated `pygrib` method in the `gdas_utility.py` script to account for 37 pressure levels. Specifically, it combines two dataarray along the dimension `level` when `levelType` is `isobaricInhPa` and `num_levels` is 37.
- Fixed a bug in downloading data from nomads server.
- Deleted hard-coded environment variables and added an argument to let the user specify the path to credential files if environment variables are not available

### Linked Issues
- Closes https://github.com/NOAA-EMC/graphcast/issues/30

### Blocking Dependencies
<!-- Example: "- Depends on #1733" or "None" -->
None

### Anticipated Changes
None
### Input data
- [ ] No changes are expected to input data.
- [x] Changes are expected to input data:
  - [x] New input data.
  - [x] Updated input data.

### Needed libraries
<!-- Library updates take time. If this PR needs updates to libraries, please make sure to accomplish the following tasks -->
None