### PR TITLE
Stop 37pl model, generate grib2 index files, update s3 resource, update readme file, update hera modules directory

### DIFF
--- a/NCEP/Readme.md
+++ b/NCEP/Readme.md
@@ -44,7 +44,7 @@ pip install --upgrade https://github.com/deepmind/graphcast/archive/master.zip
 ```
 
 ```bash
-pip isntall  pygrib requests bs4
+pip isntall pygrib requests bs4
 ```
 
 If your OS is MacOS, wget has to be installed:

--- a/NCEP/Readme.md
+++ b/NCEP/Readme.md
@@ -43,6 +43,17 @@ conda install --channel conda-forge cartopy
 pip install --upgrade https://github.com/deepmind/graphcast/archive/master.zip
 ```
 
+```bash
+pip isntall  pygrib requests bs4
+```
+
+If your OS is MacOS, wget has to be installed:
+
+```bash
+brew install wget
+```
+
+
 If you would like to save as grib2 format, the following packages are needed:
 
 ```bash

--- a/NCEP/cronjob_cloud.sh
+++ b/NCEP/cronjob_cloud.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 sbatch /contrib/Sadegh.Tabas/operational/graphcast/NCEP/gcjob_13pl_cloud.sh
-sbatch /contrib/Sadegh.Tabas/operational/graphcast/NCEP/gcjob_37pl_cloud.sh
+# sbatch /contrib/Sadegh.Tabas/operational/graphcast/NCEP/gcjob_37pl_cloud.sh

--- a/NCEP/gc_datadissm_hera.sh
+++ b/NCEP/gc_datadissm_hera.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # load necessary modules
-module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core
+module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core
 module load stack-intel
 module load wgrib2
 module load awscli-v2

--- a/NCEP/gc_prepdata_hera.sh
+++ b/NCEP/gc_prepdata_hera.sh
@@ -2,7 +2,7 @@
 
 
 # load necessary modules
-module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core
+module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core
 module load stack-intel
 module load wgrib2
 module load awscli-v2

--- a/NCEP/gc_runfcst_hera.sh
+++ b/NCEP/gc_runfcst_hera.sh
@@ -10,7 +10,7 @@
 
 
 # load necessary modules
-module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core
+module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core
 module load stack-intel
 module load wgrib2
 module load awscli-v2

--- a/NCEP/utils/nc2grib.py
+++ b/NCEP/utils/nc2grib.py
@@ -3,6 +3,7 @@
     History:
         01/26/2024: Linlin Cui (linlin.cui@noaa.gov), added function save_grib2 
         02/05/2024: Sadegh Tabas update the utility to a object-oriented format
+        04/25/2024: Sadegh Tabas, generate grib2 index files
 """
 
 import os
@@ -137,6 +138,10 @@ class Netcdf2Grib:
                     elif var_name == 'mean_sea_level_pressure':
                         cube_slice.add_aux_coord(iris.coords.DimCoord(self.ATTR_MAPS[var_name][0], standard_name='altitude', units='m'))
                         iris_grib.save_messages(self.tweaked_messages(cube_slice, f'{hrs-6}-{hrs}'), outfile, append=True)
+
+                # Use wgrib2 to generate index files
+                wgrib2_command = ['wgrib2', '-s', outfile, '>', outfile+'.idx']
+                subprocess.run(wgrib2_command, check=True)
 
         # Remove intermediate netCDF file
         if os.path.isfile(filename):

--- a/NCEP/utils/nc2grib.py
+++ b/NCEP/utils/nc2grib.py
@@ -139,9 +139,23 @@ class Netcdf2Grib:
                         cube_slice.add_aux_coord(iris.coords.DimCoord(self.ATTR_MAPS[var_name][0], standard_name='altitude', units='m'))
                         iris_grib.save_messages(self.tweaked_messages(cube_slice, f'{hrs-6}-{hrs}'), outfile, append=True)
 
-                # Use wgrib2 to generate index files
-                wgrib2_command = ['wgrib2', '-s', outfile, '>', outfile+'.idx']
-                subprocess.run(wgrib2_command, check=True)
+            # Use wgrib2 to generate index files
+            output_idx_file = f"{outfile}.idx"
+            
+            # Construct the wgrib2 command
+            wgrib2_command = ['wgrib2', '-s', outfile]
+            
+            try:
+                # Open the output file for writing
+                with open(output_idx_file, "w") as f_out:
+                    # Execute the wgrib2 command and redirect stdout to the output file
+                    subprocess.run(wgrib2_command, stdout=f_out, check=True)
+            
+                print(f"Index file created successfully: {output_idx_file}")
+            
+            except subprocess.CalledProcessError as e:
+                print(f"Error running wgrib2 command: {e}")
+    
 
         # Remove intermediate netCDF file
         if os.path.isfile(filename):


### PR DESCRIPTION
### Description
This PR addresses multiple issues including: 

- Temporarily stop running the model for 37 pressure levels due to strorage and accuracy limitations
- Generate index files for grib2 forecasts
- Update S3 bucket resource that provides historical gdas data from 20210321 to present and is available for public use
- Update readme file
- Update hera modules directory due to Rocky8 upgrade

### Linked Issues
- Closes https://github.com/NOAA-EMC/graphcast/issues/41
- Closes https://github.com/NOAA-EMC/graphcast/issues/40
- Closes https://github.com/NOAA-EMC/graphcast/issues/36
- Closes https://github.com/NOAA-EMC/graphcast/pull/38

### Blocking Dependencies
<!-- Example: "- Depends on #1733" or "None" -->

## Anticipated Changes
### Input data
- [x] No changes are expected to input data.
- [ ] Changes are expected to input data:
  - [ ] New input data.
  - [ ] Updated input data.

### Needed libraries
<!-- Library updates take time. If this PR needs updates to libraries, please make sure to accomplish the following tasks -->
- 