### PR TITLE
Update nc2grib.py to generate variables in the same order for each grib2 file in different cycles

### DIFF
--- a/NCEP/utils/nc2grib.py
+++ b/NCEP/utils/nc2grib.py
@@ -102,7 +102,7 @@ class Netcdf2Grib:
             outfile = os.path.join(outdir, f'graphcastgfs.t{cycle:02d}z.pgrb2.0p25.f{hrs:03d}')
             print(outfile)
 
-            for cube in cubes:
+            for cube in sorted(cubes, key=lambda cube: cube.name()):
                 var_name = cube.name()
 
                 # Adjust cube for different variables

--- a/NCEP/utils/nc2grib.py
+++ b/NCEP/utils/nc2grib.py
@@ -4,6 +4,7 @@
         01/26/2024: Linlin Cui (linlin.cui@noaa.gov), added function save_grib2 
         02/05/2024: Sadegh Tabas update the utility to a object-oriented format
         04/25/2024: Sadegh Tabas, generate grib2 index files
+        07/01/2024: Sadegh Tabas, sorted grib2 variables
 """
 
 import os


### PR DESCRIPTION
### Description
The variables in the grib2 files need to be ordered to prevent confusing about two APCP variables (one 6 hourly accumulation, e.g. 12-18 h, and the other one which is accumulated from the beginning e.g., 0-18 h). With this PR the forecast variables would have consistent order in all forecast cycles.

### Linked Issues
- Closes https://github.com/NOAA-EMC/graphcast/issues/46

### Blocking Dependencies
<!-- Example: "- Depends on #1733" or "None" -->

## Anticipated Changes
### Input data
- [x] No changes are expected to input data.
- [ ] Changes are expected to input data:
  - [ ] New input data.
  - [ ] Updated input data.

### Needed libraries
<!-- Library updates take time. If this PR needs updates to libraries, please make sure to accomplish the following tasks -->
- 