### PR TITLE
Update directory to fine tuned model weights

### DIFF
--- a/NCEP/run_graphcast.py
+++ b/NCEP/run_graphcast.py
@@ -7,6 +7,7 @@ Revision history:
     -20240125: Linlin Cui, added a capability to save output as grib2 format
     -20240205: Sadegh Tabas, made the code clearer, added 37 pressure level option, updated upload to s3
     -20240731: Sadegh Tabas, added grib2 file for F000
+    -20240815: Sadegh Tabas, update the directory of fine tuned model parameters
 '''
 import os
 import argparse
@@ -62,7 +63,7 @@ class GraphCastModel:
     def load_pretrained_model(self):
         """Load pre-trained GraphCast model."""
         if self.num_pressure_levels==13:
-            model_weights_path = f"{self.pretrained_model_path}/params/GraphCast_operational - ERA5-HRES 1979-2021 - resolution 0.25 - pressure levels 13 - mesh 2to6 - precipitation output only.npz"
+            model_weights_path = f"{self.pretrained_model_path}/params/GCGFSv2_finetuned - GDAS - ERA5 - resolution 0.25 - pressure levels 13 - mesh 2to6 - precipitation output only.npz"
         else:
             model_weights_path = f"{self.pretrained_model_path}/params/GraphCast - ERA5 1979-2017 - resolution 0.25 - pressure levels 37 - mesh 2to6 - precipitation input and output.npz"
 


### PR DESCRIPTION
### Description
This PR updated the directory of model parameters to the GCGFS fine-tuned version. The model weights as well as training data are also publicly available through NOAA GraphCastGFS S3 bucket. There are two set of weights for GraphCastGFS model (i) fully trained using GDAS analysis data, (ii) fine-tuned using GDAS and ERA5 reanalysis data. The fined-tuned set of weights were selected to be used for operational model due to better performance.
https://noaa-nws-graphcastgfs-pds.s3.amazonaws.com/index.html

### Linked Issues
- Closes https://github.com/NOAA-EMC/graphcast/issues/1
- Closes https://github.com/NOAA-EMC/graphcast/issues/8

### Blocking Dependencies
<!-- Example: "- Depends on #1733" or "None" -->

## Anticipated Changes
### Input data
- [x] No changes are expected to input data.
- [ ] Changes are expected to input data:
  - [ ] New input data.
  - [ ] Updated input data.

### Needed libraries
<!-- Library updates take time. If this PR needs updates to libraries, please make sure to accomplish the following tasks -->
- 